### PR TITLE
Add webpush headers

### DIFF
--- a/Gateways/Python/main.py
+++ b/Gateways/Python/main.py
@@ -20,11 +20,18 @@ async def topic(request):
 
     body = await request.body()
 
+    headers = httpx.Headers({
+        "TTL": "2592000", # 30 days
+        "Content-Encoding": "aes128gcm", # Fake this encoding to be web push compliant
+        "Urgency": "high"
+    })
+
     # Forward the request to the target URL
     async with httpx.AsyncClient() as client:
         upstream_response = await client.post(
             url=path,
             data=body,
+            headers=headers,
         )
 
     return Response(

--- a/Gateways/Rust/src/main.rs
+++ b/Gateways/Rust/src/main.rs
@@ -18,6 +18,9 @@ async fn topic(State(client): State<Client>, Path(path): Path<String>, body: Byt
     let reqwest_response = match client
         .post(&path)
         .body(body)
+        .header("TTL", "2592000") // 30 days
+        .header("Content-Encoding", "aes128gcm") // Fake this encoding to be web push compliant
+        .header("Urgency", "high")
         .send()
         .await
     {


### PR DESCRIPTION
Fake encryption ; this is ok because it just send a ping

UnifiedPush is based on WebPush; which require encryption. Some distributor like Sunup require the encryption header, so this patch fake the encryption so it works with these distrib

cf. https://codeberg.org/Sunup/android/issues/52
cf. https://codeberg.org/UnifiedPush/wishlist/issues/22

PS: I've not tested the code, I've done it quickly