### PR TITLE
Fix save-to-downloads silently skipping freshly downloaded media

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
@@ -4977,6 +4977,7 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
         private CountDownLatch waitingForFile;
         private MessagesStorage.IntCallback onFinishRunnable;
         private boolean isMusic;
+        private final HashMap<String, File> downloadedFiles = new HashMap<>();
 
         public MediaLoader(Context context, AccountInstance accountInstance, ArrayList<MessageObject> messages, MessagesStorage.IntCallback onFinish) {
             currentAccount = accountInstance;
@@ -5050,8 +5051,11 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                             if (cancelled) {
                                 break;
                             }
-                            if (!sourceFile.exists()) {
-                                sourceFile = FileLoader.getInstance(currentAccount.getCurrentAccount()).getPathToAttach(message.messageOwner, true);
+                            File downloadedFile = downloadedFiles.remove(FileLoader.getAttachFileName(document));
+                            if (downloadedFile != null && downloadedFile.exists()) {
+                                sourceFile = downloadedFile;
+                            } else if (!sourceFile.exists()) {
+                                sourceFile = FileLoader.getInstance(currentAccount.getCurrentAccount()).getPathToMessage(message.messageOwner, true);
                                 FileLog.d("saving file: correcting path from " + path + " to " + (sourceFile == null ? null : sourceFile.getAbsolutePath()));
                             }
                             if (sourceFile != null && sourceFile.exists()) {
@@ -5373,6 +5377,9 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
             if (id == NotificationCenter.fileLoaded || id == NotificationCenter.fileLoadFailed) {
                 String fileName = (String) args[0];
                 if (loadingMessageObjects.remove(fileName) != null) {
+                    if (id == NotificationCenter.fileLoaded && args.length > 1 && args[1] instanceof File) {
+                        downloadedFiles.put(fileName, (File) args[1]);
+                    }
                     waitingForFile.countDown();
                 }
             } else if (id == NotificationCenter.fileLoadProgressChanged) {


### PR DESCRIPTION
## Bug
"Save to Downloads" on media that isn't stored locally yet intermittently
saves nothing: the first attempt silently does nothing (progress dialog
closes, no file appears), and repeating the same save works.
Race-dependent; affects the API 29+ `MediaLoader` path (documents, music,
photos). The broken fallback has been there since the 11.1.3 update.

## Root cause
After waiting for the download, `MediaLoader` re-resolves the source path
through `FilePathDatabase` instead of using what the downloader already
knows. Three stacked issues:

1. **Broken fallback resolution.** The correction path called
   `getPathToAttach(TLRPC.Message)`: `getAttachFileName()` returns `""`
   for `Message` objects, so the resolved "file" was the cache *directory*
   itself. On top of that, `forceCache=true` pinned `MEDIA_DIR_CACHE`,
   while files may be stored in `MEDIA_DIR_FILES`.
2. **Read/write race on FilePathDatabase.** `putPath()` persists
   asynchronously on `files_database_queue`, while the correction lookup
   read synchronously — the stale read won the race and returned a path
   that didn't exist yet.
3. **NULL_PATH sentinel short-circuit.** Even queue-ordered reads
   short-circuit on the in-memory `~null~` sentinel cached by an earlier
   miss, so the resolved path could still be missing right after the
   download completed.

Result: `sourceFile.exists() == false` → item silently skipped
(`copiedFiles` not incremented), which is why the first attempt no-ops
and the second one (DB now populated) succeeds.

## Fix
- Capture the authoritative `finalFile` delivered with the `fileLoaded`
  notification (`args[1]`) and use it directly as the copy source.
- Keep a `FilePathDatabase` re-resolution only as a fallback, routed
  through the same dispatch queue as `putPath`
  (`useFileDatabaseQueue=true`) so FIFO ordering guarantees the write
  lands before the read.